### PR TITLE
Two hamburger icon is showing in mobile view but desktop showing one …

### DIFF
--- a/style.css
+++ b/style.css
@@ -204,7 +204,7 @@ body{
   position: absolute;
   top: 45px;
   right: 15px;
-  display: none;
+  display: block;
 }
 
 .sidenav button,
@@ -333,7 +333,7 @@ body{
 
   .sidenav {
     height: auto;
-    position: absolute;
+    position: sticky;
     padding-top: 0.5rem;
     left: -250px;
     height: 100vh;
@@ -345,7 +345,7 @@ body{
     position: absolute;
     left: 10px;
     top: 5px;
-    display: block;
+    display: none;
   }
 
   .sidenav .cross {


### PR DESCRIPTION
Two hamburger icon is showing in mobile view but desktop showing one and hamburger not working properly in mobile #97


## Description
Remove Extra hamburger icon from mobile view
Bug

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--- See how your change affects other areas of the code, etc. -->

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if necessary):
In mobile View
![image](https://github.com/EternoSeeker/gameoflife/assets/59639410/d2200888-698f-4757-abd0-38dfc3658e2f)
![image](https://github.com/EternoSeeker/gameoflife/assets/59639410/89504ace-6c99-4a66-b2f9-9e607fe53208)
In ipad view
![image](https://github.com/EternoSeeker/gameoflife/assets/59639410/9a5ce7c8-9cd4-43bb-9443-53b408c8f2fd)
in desktop view
![image](https://github.com/EternoSeeker/gameoflife/assets/59639410/fe9aabc1-5088-4f1b-8190-daf36c47029a)


