### PR TITLE
Removing Redundant Sidebar Screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ The first generation is created by applying the above rules simultaneously to ev
 
 ### ⚙️ The Settings
 
-![Game Sidebar](data/game-images/Game-Sidebar.png)
-
 | Settings | What are they for? |
 | --- | --- |
 | `Gridlines` | Toggles visibility of the gridlines |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request proposes removing the screenshot currently used to illustrate the settings menu. The rationale behind this change is twofold:

Reduced Repository Size: The screenshot occupies unnecessary space in the codebase. Removing it will contribute to a smaller repository size, leading to faster cloning and overall improved efficiency.

Clear Documentation: The functionalities of each settings tab are already well-documented in the text below the screenshot. This written description provides a more concise and maintainable explanation compared to an image.

## Related Issue
resolves #135 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--- See how your change affects other areas of the code, etc. -->

## Checklist
- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings

## Screenshots (if necessary):

