### PR TITLE
SOLVES: Initial Grid Formation Bug

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -388,12 +388,21 @@ function randomGrid() {
   // then allow user to set the cells to random state
   aliveCount = 0;
   if (!isStarted && !isAnimating) {
+    
+    // Removes the older grid
+    while (gridContainer.firstChild) {
+      gridContainer.removeChild(gridContainer.firstChild);
+    }
+
+    // Sets grid stats
     for (let i = 0; i < HEIGHT; i++) {
       for (let j = 0; j < WIDTH; j++) {
         cells[i][j] = Math.random() * 100 < randomValue ? ALIVE : DEAD;
         if(cells[i][j] == ALIVE) aliveCount++;
       }
     }
+    // Initializes New Grid and draws random cells
+    initializeGrid();
     drawCells();
   }
 }
@@ -403,11 +412,22 @@ function clearGrid() {
   // then allow user to clear the grid
   if (!isAnimating) {
     aliveCount = 0;
+    
+    // Removes the older grid and creates a fresh new one with dead cells
+    while (gridContainer.firstChild) {
+      gridContainer.removeChild(gridContainer.firstChild);
+    }
+
+    //Sets cell value to dead
     for (let i = 0; i < HEIGHT; i++) {
       for (let j = 0; j < WIDTH; j++) {
         cells[i][j] = DEAD;
       }
     }
+
+    
+    // Initializes a new grid with dead cells
+    initializeGrid();
     drawCells();
   }
   isStarted = false;

--- a/js/app.js
+++ b/js/app.js
@@ -388,21 +388,12 @@ function randomGrid() {
   // then allow user to set the cells to random state
   aliveCount = 0;
   if (!isStarted && !isAnimating) {
-    
-    // Removes the older grid
-    while (gridContainer.firstChild) {
-      gridContainer.removeChild(gridContainer.firstChild);
-    }
-
-    // Sets grid stats
     for (let i = 0; i < HEIGHT; i++) {
       for (let j = 0; j < WIDTH; j++) {
         cells[i][j] = Math.random() * 100 < randomValue ? ALIVE : DEAD;
         if(cells[i][j] == ALIVE) aliveCount++;
       }
     }
-    // Initializes New Grid and draws random cells
-    initializeGrid();
     drawCells();
   }
 }
@@ -412,22 +403,11 @@ function clearGrid() {
   // then allow user to clear the grid
   if (!isAnimating) {
     aliveCount = 0;
-    
-    // Removes the older grid and creates a fresh new one with dead cells
-    while (gridContainer.firstChild) {
-      gridContainer.removeChild(gridContainer.firstChild);
-    }
-
-    //Sets cell value to dead
     for (let i = 0; i < HEIGHT; i++) {
       for (let j = 0; j < WIDTH; j++) {
         cells[i][j] = DEAD;
       }
     }
-
-    
-    // Initializes a new grid with dead cells
-    initializeGrid();
     drawCells();
   }
   isStarted = false;

--- a/js/app.js
+++ b/js/app.js
@@ -27,11 +27,6 @@ let isGridVisible = true;
 let aliveCount = 0;
 
 
-//function to change grid size
-document.addEventListener("DOMContentLoaded", () => {
-  initializeGrid();
-});
-
 function initializeGrid() {
   const gridContainer = document.getElementById("main-grid");
 


### PR DESCRIPTION
This single piece of code was disrupting the whole webpage
- A second grid was created under the initial grid when the page loads.


## Description
A piece of code that initialised the grid everytime the page loads was deleted as it initialised the code twice.
It is a bug fix.

## Related Issue

This PR closes 2 issues,
- BUG: Initial Grid Formations - Closes #234 


## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if necessary):

![image](https://github.com/EternoSeeker/gameoflife/assets/138643473/ae1a70d0-ad7e-4e9a-82e8-630f71da4cfd)

---

|              Before             |               After              |
:-------------------------:|:-------------------------:
| ![](https://private-user-images.githubusercontent.com/138643473/337858545-a789da15-17d1-4c69-ba1f-aee09539ca21.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTc4MzU4MzEsIm5iZiI6MTcxNzgzNTUzMSwicGF0aCI6Ii8xMzg2NDM0NzMvMzM3ODU4NTQ1LWE3ODlkYTE1LTE3ZDEtNGM2OS1iYTFmLWFlZTA5NTM5Y2EyMS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNjA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDYwOFQwODMyMTFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1iMjA1Mzg1ZWEwZjBlZTUwMThmMDcxYjgwZDZkMTU1YmUzMWFkMzk0NzE5MzFmMjI4MzYyOTUzODMwNTUyODk4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.6OY5YmWo63BO8cD_RK6p8olbSuPdD1GqsjaFHOTJK5M)  |  ![](https://github.com/EternoSeeker/gameoflife/assets/138643473/9f2c6f92-704b-4d4c-90dc-50d5e0e34de5) |