### PR TITLE
Fixed: Custom Theme and Gradient color didn't immediately change the Grid cell colors

### DIFF
--- a/js/customTheme.js
+++ b/js/customTheme.js
@@ -37,6 +37,13 @@ const defaultColors = {
   }
 
   function applyColors() {
+    
+    while (gridContainer.firstChild) {
+      gridContainer.removeChild(gridContainer.firstChild);
+    }
+  
+    initializeGrid();
+
     const root = document.documentElement;
 
     root.style.setProperty('--primary-color', document.getElementById('primary-color').value);
@@ -50,6 +57,8 @@ const defaultColors = {
     root.style.setProperty('--scrollbar-color', document.getElementById('scrollbar-color').value);
     ALIVE_COLOR = document.getElementById('alive-color').value;
     DEAD_COLOR = document.getElementById('dead-color').value;
+
+    drawCells();
 
     saveColors();
     title.style.color = isDark(color1) ? '#ffffff' : '#000000';
@@ -65,6 +74,7 @@ const defaultColors = {
     DEAD_COLOR = "#CADCFC";
     loadColorInputs();  // Update the color pickers to reflect default values
     document.getElementById('custom-colors-container').style.display = 'none'; //Hide the Container if reset to default
+    drawCells();
   }
 
 
@@ -107,10 +117,12 @@ function isDark(color) {
 slopeSlider.addEventListener('input', function() {
   ALIVE_COLOR = document.getElementById('color1').value;
   DEAD_COLOR = document.getElementById('color2').value;
+  drawCells();
 });
 
 // Event listener for the Apply Gradient button
 document.getElementById('apply-gradient-btn').addEventListener('click', function() {
   ALIVE_COLOR = document.getElementById('color1').value;
   DEAD_COLOR = document.getElementById('color2').value;
+  drawCells();
 });


### PR DESCRIPTION
### The grid cell colors are stored in a different variable and hence the changes in them are not visible until you perform any action on the grid like toggle, clear, random, animate etc

## Description
Now the code draws all the cell when you change the theme , so the grid colour changes when you apply the theme.
It is a bug fix.

## Related Issue
This bug fix closes #228 

## Motivation and Context
### The grid cell colors are stored in a different variable and hence the changes in them are not visible until you perform any action on the grid

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

