### PR TITLE
resolved non visibility of settings button for themes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -342,7 +342,7 @@ body{
   transform: translateY(0.1rem);
 }
 #toggleButton {
-    color: black;
+    color: var(--primary-color);
     border-radius: 5px;
     border-style: none;
     font-size: 1.7rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Resolved non visibility of settings button for themes (dark neon theme) but the visibility of settings icon is all dynamic based on the theme chosen.
Issue no solved : #314 
## Description
<!--- Describe your changes in detail -->
<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->
Resolved non visibility of settings button for themes (dark neon theme) but the visibility of settings icon is all dynamic based on the theme chosen. Dynamically the color and visibility is according to the theme. It is a small bug which just required an enhancement.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Settings icon was not visible for theme like dark neon  theme.

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--- See how your change affects other areas of the code, etc. -->
Available and visible for all themes now.
## Checklist
- [x ] I have performed a self-review of my code
- [ x] My changes generate no new warnings

## Screenshots (if necessary):
![Screenshot_20240624_114819](https://github.com/EternoSeeker/gameoflife/assets/121295967/8119069a-d4a2-4130-9d73-ef9f403e84e4)
![Screenshot_20240624_115804](https://github.com/EternoSeeker/gameoflife/assets/121295967/1b81a8c8-af48-4d95-9060-dfb70e8bb41c)
![Screenshot_20240624_115753](https://github.com/EternoSeeker/gameoflife/assets/121295967/58efa941-437d-4482-a56f-beb65575f6f6)
![Screenshot_20240624_115739](https://github.com/EternoSeeker/gameoflife/assets/121295967/37b8f49d-8314-4bbe-bb0e-60ddf7997981)
etc for all themes its visible.
