### PR TITLE
feedback form margin/padding fix so form not cuts

### DIFF
--- a/css/feedback.css
+++ b/css/feedback.css
@@ -45,7 +45,7 @@ input[type="file"]:focus {
   
   .container {
     background: #fff;
-    padding: 20px 30px;
+    padding: 8px 30px;
     border-radius: 8px;
     box-shadow: 0 12px 36px rgba(161, 195, 232, 0.3);
     width: 100%;
@@ -59,8 +59,13 @@ input[type="file"]:focus {
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   }
   
+  #feedback-form{
+  margin-top: 2px;
+  margin-bottom: 2px;
+ }
+
   h1 {
-    margin-top: 0;
+    margin-top: 10px;
     font-size: 24px;
     text-align: center;
     color: #333;

--- a/css/feedback.css
+++ b/css/feedback.css
@@ -45,7 +45,7 @@ input[type="file"]:focus {
   
   .container {
     background: #fff;
-    padding: 8px 30px;
+    padding: 0.5rem 1.875rem;
     border-radius: 8px;
     box-shadow: 0 12px 36px rgba(161, 195, 232, 0.3);
     width: 100%;
@@ -59,13 +59,13 @@ input[type="file"]:focus {
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   }
   
-  #feedback-form{
-  margin-top: 2px;
-  margin-bottom: 2px;
- }
-
+  #feedback-form {
+    margin-top: 0.125rem; 
+    margin-bottom: 0.125rem;
+  }
+  
   h1 {
-    margin-top: 10px;
+    margin-top: 0.625rem;
     font-size: 24px;
     text-align: center;
     color: #333;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix forms cuts from up and down part.
Now no scrollbar visible.
Make form in one single page no need to scroll and no cuts from up and down side.
Add some margins in forms and h1.
Changes in padding of form.

## Related Issue

Fixes #326

## Motivation and Context
For better visibility.

## How Has This Been Tested?
Self checked

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if necessary):
![image](https://github.com/EternoSeeker/gameoflife/assets/126322584/68fd9c08-0824-4135-8880-7739bbe38faf)

