### PR TITLE
Fix margins for small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -706,6 +706,8 @@ body {
     /* Adjust padding for smaller screens */
     margin: 0.5rem 0;
     /* Add margin to separate buttons vertically */
+    margin-left: 0.6rem;
+    margin-right: 0.6rem;
   }
 
   .grid-container {
@@ -729,6 +731,16 @@ body {
     text-align: center;
     padding-top: 0.7rem;
     padding-bottom: 0.7rem;
+  }
+}
+
+@media screen and (max-width: 700px) 
+{
+  .clear-button,
+  .random-button {
+    font-size: 0.8rem;
+    margin-left: 0.6rem;
+    margin-right: 0.6rem;
   }
 }
 


### PR DESCRIPTION
 In small screen not proper margins in buttons

## Description

Added Proper margin left and margin right so overlapping solved and looks good.

## Related Issue

Fixes #363 

## Motivation and Context

Better UI

## How Has This Been Tested?

Self test by run

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if necessary):

![image](https://github.com/EternoSeeker/gameoflife/assets/126322584/54cc9f85-5279-4fa1-b3d8-948277ba390d)

