### PR TITLE
Implemented W key as Wrap toggle

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -421,6 +421,7 @@ function startAnimation() {
 
 function toggleWarp() {
   isWarpEnabled = !isWarpEnabled;
+  document.getElementById("warp-on-edges").checked = isWarpEnabled;
 }
 
 //randomGrid()
@@ -461,9 +462,9 @@ function clearGrid() {
   }
 }
 
-function toggleWarp() {
-  isWarpEnabled = !isWarpEnabled;
-}
+// function toggleWarp() {
+//   isWarpEnabled = !isWarpEnabled;
+// }
 
 function toggleGrid() {
   isGridVisible = !isGridVisible;

--- a/js/keyboard-shortcut.js
+++ b/js/keyboard-shortcut.js
@@ -19,6 +19,7 @@ document.addEventListener("keydown", function (event) {
       ARROWDOWN: () => updateRandomValue(-5),
       G: toggleGrid,
       M: toggleMusic,
+      W: toggleWarp
     };
   
     // Check if a function is mapped to the pressed key


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->
Pressing the 'W' button  now toggles the Wrap-Around-Edges 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
#413 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The rest of the options were toggle-able by keyboard


## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if necessary):

